### PR TITLE
Add scripts dir to pubignore

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -36,3 +36,4 @@ build/
 
 # Only in .pubignore
 /test_app/*
+/scripts/*


### PR DESCRIPTION
The scripts dir contain development tools and should not be published
to pub.dev.