### PR TITLE
Make spinkit a prod dependency

### DIFF
--- a/test_app/pubspec.lock
+++ b/test_app/pubspec.lock
@@ -124,7 +124,7 @@ packages:
     source: hosted
     version: "2.0.7"
   flutter_spinkit:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: flutter_spinkit
       url: "https://pub.dartlang.org"

--- a/test_app/pubspec.yaml
+++ b/test_app/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   permission_handler: ^10.0.0
   shared_preferences: ^2.0.15
   collection: ^1.16.0
+  flutter_spinkit: ^5.1.0
 
   dolbyio_comms_sdk_flutter:
     # When depending on this package from a real application you should use:
@@ -43,7 +44,6 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_spinkit: ^5.1.0
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is


### PR DESCRIPTION
The flutter_spinkit depndency in the test_app is now a production depndency. Perviously as put as a develop depenency by mistake.