### PR TITLE
Fix optional param decoding in bindings

### DIFF
--- a/ios/Classes/Common/BindingUtils.swift
+++ b/ios/Classes/Common/BindingUtils.swift
@@ -57,7 +57,7 @@ struct FlutterMethodCallArguments {
         return Argument(argArray[argIndex])
     }
 
-    func asDictionary(argKey: String, optional: Bool = false, file: String = #filePath, lineNumber: Int = #line) throws -> Argument {
+    func asDictionary(argKey: String, optional: Bool = true, file: String = #filePath, lineNumber: Int = #line) throws -> Argument {
         guard let argDictionary = methodCallArguments as? [String: Any] else {
             throw EncoderError.notDictionary(file: file, lineNumber: lineNumber)
         }


### PR DESCRIPTION
The `FlutterMethodCallArguments.asDictionaryI()` paramenter `optional` had a default falue of `false`. It has now been changed to `true` untill all optional arguments are found, and the `optional` parameter is set accordingly.

Please note that `FlutterMethodCallArguments.asDictionary()` treated all arguments as optional before the `optional` parameter was added.