### PR TITLE
Fix participant screen poping on rejoin

### DIFF
--- a/test_app/lib/screens/participant_screen/participant_screen.dart
+++ b/test_app/lib/screens/participant_screen/participant_screen.dart
@@ -167,11 +167,6 @@ class _ParticipantScreenContentState extends State<ParticipantScreenContent> {
         .getParticipants(currentConference);
     final localParticipant =
         await _dolbyioCommsSdkFlutterPlugin.conference.getLocalParticipant();
-    if (localParticipant.status == ParticipantStatus.left ||
-        localParticipant.status == ParticipantStatus.kicked) {
-      navigator.popUntil(ModalRoute.withName("JoinConferenceScreen"));
-      return Future.value();
-    }
     final availableParticipants = conferenceParticipants
         .where((element) => element.status != ParticipantStatus.left);
     if (availableParticipants.isNotEmpty) {


### PR DESCRIPTION
When rejoining a conference on iOS after leaving without closing the seesion, the participant screen was poped strait after joining. This has been fixed in the commit.