### PR TITLE
Add possibility to set spatial environment to a user defined value

### DIFF
--- a/test_app/lib/screens/test_buttons/conference_service_test_buttons.dart
+++ b/test_app/lib/screens/test_buttons/conference_service_test_buttons.dart
@@ -1,4 +1,5 @@
 import 'package:dolbyio_comms_sdk_flutter_example/conference_ext.dart';
+import 'package:dolbyio_comms_sdk_flutter_example/widgets/spatial_environment/spatial_environment_dialog_content.dart';
 import 'package:flutter/material.dart';
 import 'package:dolbyio_comms_sdk_flutter/dolbyio_comms_sdk_flutter.dart';
 import '/widgets/secondary_button.dart';
@@ -59,7 +60,7 @@ class ConferenceServiceTestButtons extends StatelessWidget {
             onPressed: () => setSpatialDirection(context)),
         SecondaryButton(
             text: 'Set spatial environment',
-            onPressed: () => setSpatialEnvironment(context)),
+            onPressed: () => setSpatialEnvironmentDialog(context)),
         SecondaryButton(
             text: 'Get local stats', onPressed: () => getLocalStats(context)),
         SecondaryButton(
@@ -80,7 +81,7 @@ class ConferenceServiceTestButtons extends StatelessWidget {
     );
   }
 
-  Future<void> showDialog(
+  Future<void> showResultDialog(
       BuildContext context, String title, String text) async {
     await ViewDialogs.dialog(
       context: context,
@@ -92,10 +93,10 @@ class ConferenceServiceTestButtons extends StatelessWidget {
   void getParticipant(BuildContext context) {
     _dolbyioCommsSdkFlutterPlugin.conference
         .getLocalParticipant()
-        .then((participant) =>
-            showDialog(context, 'Success', participant.toJson().toString()))
+        .then((participant) => showResultDialog(
+            context, 'Success', participant.toJson().toString()))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void getParticipants(BuildContext context) {
@@ -104,9 +105,9 @@ class ConferenceServiceTestButtons extends StatelessWidget {
         .then((conference) => _dolbyioCommsSdkFlutterPlugin.conference
             .getParticipants(conference))
         .then((participants) =>
-            showDialog(context, 'Success', jsonEncode(participants)))
+            showResultDialog(context, 'Success', jsonEncode(participants)))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void fetchConference(BuildContext context) {
@@ -114,19 +115,19 @@ class ConferenceServiceTestButtons extends StatelessWidget {
         .current()
         .then((conference) =>
             _dolbyioCommsSdkFlutterPlugin.conference.fetch(conference.id))
-        .then((conference) =>
-            showDialog(context, 'Success', conference.toJson().toString()))
+        .then((conference) => showResultDialog(
+            context, 'Success', conference.toJson().toString()))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void current(BuildContext context) {
     _dolbyioCommsSdkFlutterPlugin.conference
         .current()
-        .then((conference) =>
-            showDialog(context, 'Success', conference.toJson().toString()))
+        .then((conference) => showResultDialog(
+            context, 'Success', conference.toJson().toString()))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void getAudioLevel(BuildContext context) {
@@ -135,17 +136,18 @@ class ConferenceServiceTestButtons extends StatelessWidget {
         .then((participant) =>
             _dolbyioCommsSdkFlutterPlugin.conference.getAudioLevel(participant))
         .then((audioLevel) =>
-            showDialog(context, 'Success', audioLevel.toString()))
+            showResultDialog(context, 'Success', audioLevel.toString()))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void isMuted(BuildContext context) {
     _dolbyioCommsSdkFlutterPlugin.conference
         .isMuted()
-        .then((isMuted) => showDialog(context, 'Success', isMuted.toString()))
+        .then((isMuted) =>
+            showResultDialog(context, 'Success', isMuted.toString()))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void setMute(BuildContext context, bool mute) {
@@ -153,43 +155,45 @@ class ConferenceServiceTestButtons extends StatelessWidget {
         .getLocalParticipant()
         .then((participant) =>
             _dolbyioCommsSdkFlutterPlugin.conference.mute(participant, mute))
-        .then((isMuted) => showDialog(context, 'Success', isMuted.toString()))
+        .then((isMuted) =>
+            showResultDialog(context, 'Success', isMuted.toString()))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void setMuteOutput(BuildContext context, bool mute) {
     _dolbyioCommsSdkFlutterPlugin.conference
         .muteOutput(mute)
-        .then((isMuted) => showDialog(context, 'Success', isMuted.toString()))
+        .then((isMuted) =>
+            showResultDialog(context, 'Success', isMuted.toString()))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void startAudio(BuildContext context) {
     _dolbyioCommsSdkFlutterPlugin.conference.getLocalParticipant().then(
         (participant) => _dolbyioCommsSdkFlutterPlugin.conference
             .startAudio(participant)
-            .then((value) => showDialog(context, 'Success', 'OK'))
+            .then((value) => showResultDialog(context, 'Success', 'OK'))
             .onError((error, stackTrace) =>
-                showDialog(context, 'Error', error.toString())));
+                showResultDialog(context, 'Error', error.toString())));
   }
 
   void stopAudio(BuildContext context) {
     _dolbyioCommsSdkFlutterPlugin.conference.getLocalParticipant().then(
         (participant) => _dolbyioCommsSdkFlutterPlugin.conference
             .stopAudio(participant)
-            .then((value) => showDialog(context, 'Success', 'OK'))
+            .then((value) => showResultDialog(context, 'Success', 'OK'))
             .onError((error, stackTrace) =>
-                showDialog(context, 'Error', error.toString())));
+                showResultDialog(context, 'Error', error.toString())));
   }
 
   void startVideo(BuildContext context) {
     _dolbyioCommsSdkFlutterPlugin.conference.getLocalParticipant().then(
         (participant) => _dolbyioCommsSdkFlutterPlugin.conference
             .startVideo(participant)
-            .then((value) => showDialog(context, 'Success', 'OK'))
-            .onError((error, stackTrace) => showDialog(
+            .then((value) => showResultDialog(context, 'Success', 'OK'))
+            .onError((error, stackTrace) => showResultDialog(
                 context, 'Error', error.toString() + stackTrace.toString())));
   }
 
@@ -197,8 +201,8 @@ class ConferenceServiceTestButtons extends StatelessWidget {
     _dolbyioCommsSdkFlutterPlugin.conference.getLocalParticipant().then(
         (participant) => _dolbyioCommsSdkFlutterPlugin.conference
             .stopVideo(participant)
-            .then((value) => showDialog(context, 'Success', 'OK'))
-            .onError((error, stackTrace) => showDialog(
+            .then((value) => showResultDialog(context, 'Success', 'OK'))
+            .onError((error, stackTrace) => showResultDialog(
                 context, 'Error', error.toString() + stackTrace.toString())));
   }
 
@@ -207,8 +211,8 @@ class ConferenceServiceTestButtons extends StatelessWidget {
         .current()
         .then((conference) =>
             _dolbyioCommsSdkFlutterPlugin.conference.startScreenShare())
-        .then((value) => showDialog(context, 'Success', 'OK'))
-        .onError((error, stackTrace) => showDialog(
+        .then((value) => showResultDialog(context, 'Success', 'OK'))
+        .onError((error, stackTrace) => showResultDialog(
             context, 'Error', error.toString() + stackTrace.toString()));
   }
 
@@ -217,8 +221,8 @@ class ConferenceServiceTestButtons extends StatelessWidget {
         .current()
         .then((conference) =>
             _dolbyioCommsSdkFlutterPlugin.conference.stopScreenShare())
-        .then((value) => showDialog(context, 'Success', 'OK'))
-        .onError((error, stackTrace) => showDialog(
+        .then((value) => showResultDialog(context, 'Success', 'OK'))
+        .onError((error, stackTrace) => showResultDialog(
             context, 'Error', error.toString() + stackTrace.toString()));
   }
 
@@ -230,38 +234,41 @@ class ConferenceServiceTestButtons extends StatelessWidget {
               participant: participant,
               position: SpatialPosition(1.0, 1.0, 1.0),
             ))
-        .then((value) => showDialog(context, 'Success', 'OK'))
+        .then((value) => showResultDialog(context, 'Success', 'OK'))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
-  void setSpatialEnvironment(BuildContext context) {
-    _dolbyioCommsSdkFlutterPlugin.conference
-        .setSpatialEnvironment(
-            SpatialScale(1.0, 1.0, 1.0),
-            SpatialPosition(0.0, 0.0, 1.0),
-            SpatialPosition(0.0, 1.0, 0.0),
-            SpatialPosition(1.0, 0.0, 0.0))
-        .then((value) => showDialog(context, 'Success', 'OK'))
-        .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+  Future<void> setSpatialEnvironmentDialog(BuildContext context) async {
+    return await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext environmentContext) {
+        return AlertDialog(
+          title: const Text('Set spatial environment'),
+          content: SpatialEnvironmentDialogContent(
+              environmentDialogContext: environmentContext,
+              resultDialogContext: context),
+        );
+      },
+    );
   }
 
   void setSpatialDirection(BuildContext context) {
     _dolbyioCommsSdkFlutterPlugin.conference
         .setSpatialDirection(SpatialDirection(1.0, 1.0, 1.0))
-        .then((value) => showDialog(context, 'Success', 'OK'))
+        .then((value) => showResultDialog(context, 'Success', 'OK'))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void getLocalStats(BuildContext context) {
     _dolbyioCommsSdkFlutterPlugin.conference
         .getLocalStats()
         .then((rtcStatsTypes) =>
-            showDialog(context, 'Success', jsonEncode(rtcStatsTypes)))
+            showResultDialog(context, 'Success', jsonEncode(rtcStatsTypes)))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void setMaxVideoForwarding(BuildContext context) {
@@ -271,9 +278,10 @@ class ConferenceServiceTestButtons extends StatelessWidget {
             .getParticipants(conference))
         .then((participants) => _dolbyioCommsSdkFlutterPlugin.conference
             .setMaxVideoForwarding(4, participants))
-        .then((value) => showDialog(context, 'Success', jsonEncode(value)))
+        .then(
+            (value) => showResultDialog(context, 'Success', jsonEncode(value)))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void setVideoForwarding(BuildContext context) {
@@ -284,9 +292,10 @@ class ConferenceServiceTestButtons extends StatelessWidget {
         .then((participants) => _dolbyioCommsSdkFlutterPlugin.conference
             .setVideoForwarding(
                 VideoForwardingStrategy.lastSpeaker, 4, participants))
-        .then((value) => showDialog(context, 'Success', jsonEncode(value)))
+        .then(
+            (value) => showResultDialog(context, 'Success', jsonEncode(value)))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void setAudioProcessing(BuildContext context) {
@@ -294,9 +303,9 @@ class ConferenceServiceTestButtons extends StatelessWidget {
     var audioProcessingOptions = AudioProcessingOptions()..send = senderOptions;
     _dolbyioCommsSdkFlutterPlugin.conference
         .setAudioProcessing(audioProcessingOptions)
-        .then((value) => showDialog(context, 'Success', 'OK'))
+        .then((value) => showResultDialog(context, 'Success', 'OK'))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void isSpeaking(BuildContext context) {
@@ -305,17 +314,17 @@ class ConferenceServiceTestButtons extends StatelessWidget {
         .then((participant) =>
             _dolbyioCommsSdkFlutterPlugin.conference.isSpeaking(participant))
         .then((isSpeaking) =>
-            showDialog(context, 'Success', isSpeaking.toString()))
+            showResultDialog(context, 'Success', isSpeaking.toString()))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 
   void getMaxVideoForwarding(BuildContext context) {
     _dolbyioCommsSdkFlutterPlugin.conference
         .getMaxVideoForwarding()
         .then((maxVideoForwarding) =>
-            showDialog(context, 'Success', maxVideoForwarding.toString()))
+            showResultDialog(context, 'Success', maxVideoForwarding.toString()))
         .onError((error, stackTrace) =>
-            showDialog(context, 'Error', error.toString()));
+            showResultDialog(context, 'Error', error.toString()));
   }
 }

--- a/test_app/lib/widgets/spatial_environment/spatial_environment_dialog_content.dart
+++ b/test_app/lib/widgets/spatial_environment/spatial_environment_dialog_content.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:dolbyio_comms_sdk_flutter/dolbyio_comms_sdk_flutter.dart';
+import 'package:dolbyio_comms_sdk_flutter_example/widgets/spatial_environment/spatial_values_row.dart';
+import '../dialogs.dart';
+
+class SpatialEnvironmentDialogContent extends StatelessWidget {
+  final TextEditingController _scaleXTextController = TextEditingController();
+  final TextEditingController _scaleYTextController = TextEditingController();
+  final TextEditingController _scaleZTextController = TextEditingController();
+  final TextEditingController _forwardXTextController = TextEditingController();
+  final TextEditingController _forwardYTextController = TextEditingController();
+  final TextEditingController _forwardZTextController = TextEditingController();
+  final TextEditingController _upXTextController = TextEditingController();
+  final TextEditingController _upYTextController = TextEditingController();
+  final TextEditingController _upZTextController = TextEditingController();
+  final TextEditingController _rightXTextController = TextEditingController();
+  final TextEditingController _rightYTextController = TextEditingController();
+  final TextEditingController _rightZTextController = TextEditingController();
+
+  final BuildContext environmentDialogContext;
+  final BuildContext resultDialogContext;
+
+  final _dolbyioCommsSdkFlutterPlugin = DolbyioCommsSdk.instance;
+
+  SpatialEnvironmentDialogContent(
+      {Key? key,
+      required this.environmentDialogContext,
+      required this.resultDialogContext})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(mainAxisSize: MainAxisSize.min, children: [
+      const Text("Spatial scale: "),
+      SpatialValuesRow(
+          xTextController: _scaleXTextController..text = '1.0',
+          yTextController: _scaleYTextController..text = '1.0',
+          zTextController: _scaleZTextController..text = '1.0'),
+      const SizedBox(height: 4),
+      const Text("Spatial position (forward) :"),
+      SpatialValuesRow(
+          xTextController: _forwardXTextController..text = '0.0',
+          yTextController: _forwardYTextController..text = '0.0',
+          zTextController: _forwardZTextController..text = '1.0'),
+      const SizedBox(height: 4),
+      const Text("Spatial position (up) :"),
+      SpatialValuesRow(
+          xTextController: _upXTextController..text = '0.0',
+          yTextController: _upYTextController..text = '1.0',
+          zTextController: _upZTextController..text = '0.0'),
+      const SizedBox(height: 4),
+      const Text("Spatial position (right) :"),
+      SpatialValuesRow(
+          xTextController: _rightXTextController..text = '1.0',
+          yTextController: _rightYTextController..text = '0.0',
+          zTextController: _rightZTextController..text = '0.0'),
+      Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          TextButton(
+            child: const Text('OK', style: TextStyle(color: Colors.deepPurple)),
+            onPressed: () {
+              setSpatialEnvironment(resultDialogContext);
+              Navigator.of(environmentDialogContext).pop();
+            },
+          ),
+          TextButton(
+            child: const Text('CANCEL',
+                style: TextStyle(color: Colors.deepPurple)),
+            onPressed: () {
+              Navigator.of(environmentDialogContext).pop();
+            },
+          )
+        ],
+      ),
+    ]);
+  }
+
+  void setSpatialEnvironment(BuildContext context) async {
+    _dolbyioCommsSdkFlutterPlugin.conference
+        .setSpatialEnvironment(
+            SpatialScale(
+                double.parse(_scaleXTextController.text.toString()),
+                double.parse(_scaleYTextController.text.toString()),
+                double.parse(_scaleZTextController.text.toString())),
+            SpatialPosition(
+                double.parse(_forwardXTextController.text.toString()),
+                double.parse(_forwardYTextController.text.toString()),
+                double.parse(_forwardZTextController.text.toString())),
+            SpatialPosition(
+                double.parse(_upXTextController.text.toString()),
+                double.parse(_upYTextController.text.toString()),
+                double.parse(_upZTextController.text.toString())),
+            SpatialPosition(
+                double.parse(_rightXTextController.text.toString()),
+                double.parse(_rightYTextController.text.toString()),
+                double.parse(_rightZTextController.text.toString())))
+        .then((value) => showResultDialog(context, 'Success', 'OK'))
+        .onError((error, stackTrace) =>
+            showResultDialog(context, 'Error', error.toString()));
+  }
+
+  Future<void> showResultDialog(
+      BuildContext context, String title, String text) async {
+    await ViewDialogs.dialog(
+      context: context,
+      title: title,
+      body: text,
+    );
+  }
+}

--- a/test_app/lib/widgets/spatial_environment/spatial_value_text_field.dart
+++ b/test_app/lib/widgets/spatial_environment/spatial_value_text_field.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class SpatialValueTextField extends StatelessWidget {
+  final String spatialHint;
+  final TextEditingController valueTextController;
+
+  const SpatialValueTextField(
+      {Key? key, required this.spatialHint, required this.valueTextController})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+        width: 40,
+        child: TextFormField(
+            controller: valueTextController,
+            textAlign: TextAlign.center,
+            decoration: InputDecoration(hintText: spatialHint),
+            keyboardType: TextInputType.number,
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'(^\d*\.?\d*)'))
+            ]));
+  }
+}

--- a/test_app/lib/widgets/spatial_environment/spatial_values_row.dart
+++ b/test_app/lib/widgets/spatial_environment/spatial_values_row.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:dolbyio_comms_sdk_flutter_example/widgets/spatial_environment/spatial_value_text_field.dart';
+
+class SpatialValuesRow extends StatelessWidget {
+  final TextEditingController xTextController;
+  final TextEditingController yTextController;
+  final TextEditingController zTextController;
+
+  const SpatialValuesRow(
+      {Key? key,
+      required this.xTextController,
+      required this.yTextController,
+      required this.zTextController})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: <Widget>[
+          const Text("x: ", style: TextStyle(fontWeight: FontWeight.bold)),
+          SpatialValueTextField(
+              spatialHint: "x", valueTextController: xTextController),
+          const Text("y: ", style: TextStyle(fontWeight: FontWeight.bold)),
+          SpatialValueTextField(
+              spatialHint: "y", valueTextController: yTextController),
+          const Text("z: ", style: TextStyle(fontWeight: FontWeight.bold)),
+          SpatialValueTextField(
+              spatialHint: "z", valueTextController: zTextController)
+        ]);
+  }
+}


### PR DESCRIPTION
- Renamed the showDialog() to showDialogResult(), because when I wanted to create a new dialog, dart read showDialog()  as showing the result dialog, not a function to create a new one. 
- Created a SpatialEnvironmentDialogContent widget with all of the TextEditingController that are needed to setSpatialEnvironment() to a user defined value
- Created a single item SpatialValueTextField to pass one of the spatial values, and a row SpatialValuesRow that has 3 values needed for each 4 parameters of the setSpatialEnvironment(). It makes the whole thing more readable.