### PR TITLE
Fix video presentation events in iOS

### DIFF
--- a/ios/Classes/Bindings/VideoPresentationServiceBinding.swift
+++ b/ios/Classes/Bindings/VideoPresentationServiceBinding.swift
@@ -17,6 +17,11 @@ private enum EventKeys: String, CaseIterable {
 
 class VideoPresentationServiceBinding: Binding {
     
+    override init(name: String, registrar: FlutterPluginRegistrar) {
+        super.init(name: name, registrar: registrar)
+        VoxeetSDK.shared.videoPresentation.delegate = self
+    }
+    
     /// Returns information about the current video presentation.
     /// - Parameters:
     ///   - completionHandler: Call methods on this instance when execution has finished.
@@ -114,7 +119,8 @@ class VideoPresentationServiceBinding: Binding {
     func state(
         completionHandler: FlutterMethodCallCompletionHandler
     ) {
-        completionHandler.success(encodable: DTO.VideoPresentationState(state: VoxeetSDK.shared.videoPresentation.state))
+        let state = DTO.VideoPresentationState(state: VoxeetSDK.shared.videoPresentation.state)
+        completionHandler.success(encodable: state)
     }
 }
 


### PR DESCRIPTION
The video presentaion events were not propagated to from iOS to Flutter. This PR fixes this issue.