### PR TITLE
Fix documentation of File.uri

### DIFF
--- a/lib/src/sdk_api/models/file_presentation.dart
+++ b/lib/src/sdk_api/models/file_presentation.dart
@@ -2,7 +2,7 @@ import 'participant.dart';
 
 /// The File class gathers information about a file that a presenter wants to share during a conference.
 class File {
-  /// The URL of a file.
+  /// The local path of a file.
   String uri;
 
   File(this.uri);


### PR DESCRIPTION
The native Android SDK does not suport remote URLs for file presentaion, hence we need to inform users that they can only use local file paths.