### PR TITLE
Save up to 5 conference aliases in shared preferences

### DIFF
--- a/test_app/lib/screens/join_screen.dart
+++ b/test_app/lib/screens/join_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:dolbyio_comms_sdk_flutter/dolbyio_comms_sdk_flutter.dart';
+import '../shared_preferences_helper.dart';
 import '/widgets/text_form_field.dart';
 import '/widgets/two_color_text.dart';
 import '/widgets/dolby_title.dart';
@@ -79,6 +80,8 @@ class _JoinConferenceContentState extends State<JoinConferenceContent> {
       "Spatial Audio with Shared Scene";
   static const String spatialAudioDisabled = "Spatial Audio Disabled";
   bool joinAsListener = false;
+  String _conferenceAlias = '';
+
   StreamSubscription<
           Event<NotificationServiceEventNames,
               InvitationReceivedNotificationData>>?
@@ -89,7 +92,7 @@ class _JoinConferenceContentState extends State<JoinConferenceContent> {
   @override
   void initState() {
     super.initState();
-
+    initSharedPreferences();
     onInvitationReceivedSubscription = _dolbyioCommsSdkFlutterPlugin
         .notification
         .onInvitationReceived()
@@ -154,13 +157,17 @@ class _JoinConferenceContentState extends State<JoinConferenceContent> {
                     blackText: "External ID  ", colorText: widget.externalId),
                 const SizedBox(height: 16),
                 Form(
-                  key: formKeyAlias,
-                  autovalidateMode: AutovalidateMode.onUserInteraction,
-                  child: InputTextFormField(
-                      labelText: 'Conference alias',
-                      controller: conferenceAliasTextController,
-                      focusColor: Colors.deepPurple),
-                ),
+                    key: formKeyAlias,
+                    autovalidateMode: AutovalidateMode.onUserInteraction,
+                    child: InputTextFormField(
+                        labelText: 'Conference alias',
+                        controller: conferenceAliasTextController,
+                        focusColor: Colors.deepPurple,
+                        isStorageNeeded: true,
+                        onStorageIconTap: () async {
+                          await showAliasSelectorDialog(context,
+                              SharedPreferencesHelper().conferenceAliases);
+                        })),
                 ExpansionTile(
                     title: const Text('Options'),
                     textColor: Colors.black,
@@ -375,12 +382,12 @@ class _JoinConferenceContentState extends State<JoinConferenceContent> {
   }
 
   ConferenceCreateOption conferenceCreateOptions() {
-    var conferenceName = conferenceAliasTextController.text;
+    _conferenceAlias = conferenceAliasTextController.text;
     var params = ConferenceCreateParameters();
     params.dolbyVoice = switchDolbyVoice;
     params.liveRecording = true;
-    var createOptions = ConferenceCreateOption(
-        conferenceName, params, 0, spatialAudioStyle);
+    var createOptions =
+        ConferenceCreateOption(_conferenceAlias, params, 0, spatialAudioStyle);
     createOptions.spatialAudioStyle = spatialAudioStyle;
     return createOptions;
   }
@@ -407,6 +414,7 @@ class _JoinConferenceContentState extends State<JoinConferenceContent> {
     } else {
       developer.log('Cannot join to conference.');
     }
+    saveToSharedPreferences();
   }
 
   void joinInvitation(String conferenceId) {
@@ -484,6 +492,61 @@ class _JoinConferenceContentState extends State<JoinConferenceContent> {
               conference: conference, isSpatialAudio: spatialAudio)),
     );
     setState(() => isJoining = false);
+  }
+
+  Future<void> showAliasSelectorDialog(
+      BuildContext context, List<String>? conferenceAliases) async {
+    return showDialog<void>(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+              title: const Text('Choose from recently saved'),
+              actionsOverflowButtonSpacing: 10,
+              content: SingleChildScrollView(
+                  child: SizedBox(
+                width: double.maxFinite,
+                child: Column(mainAxisSize: MainAxisSize.min, children: [
+                  if (conferenceAliases != null)
+                    ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: conferenceAliases.length,
+                        itemBuilder: (context, index) {
+                          String alias = conferenceAliases[index];
+                          return ListTile(
+                              title: Text(alias),
+                              onTap: () => onAliasTap(alias));
+                        })
+                  else
+                    const Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text('No aliases in storage.'))
+                ]),
+              )),
+              actions: [
+                TextButton(
+                    style: TextButton.styleFrom(primary: Colors.deepPurple),
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('Cancel')),
+              ]);
+        });
+  }
+
+  void onAliasTap(String alias) {
+    conferenceAliasTextController.text = alias;
+    Navigator.of(context).pop();
+  }
+
+  void initSharedPreferences() {
+    try {
+      conferenceAliasTextController.text =
+          SharedPreferencesHelper().latestAlias;
+    } catch (error) {
+      onError('Cannot load data from shared preferences.', error);
+    }
+  }
+
+  void saveToSharedPreferences() {
+    SharedPreferencesHelper().latestAlias = _conferenceAlias;
   }
 
   void onError(String message, Object? error) {

--- a/test_app/lib/screens/join_screen.dart
+++ b/test_app/lib/screens/join_screen.dart
@@ -157,17 +157,21 @@ class _JoinConferenceContentState extends State<JoinConferenceContent> {
                     blackText: "External ID  ", colorText: widget.externalId),
                 const SizedBox(height: 16),
                 Form(
-                    key: formKeyAlias,
-                    autovalidateMode: AutovalidateMode.onUserInteraction,
-                    child: InputTextFormField(
-                        labelText: 'Conference alias',
-                        controller: conferenceAliasTextController,
-                        focusColor: Colors.deepPurple,
-                        isStorageNeeded: true,
-                        onStorageIconTap: () async {
-                          await showAliasSelectorDialog(context,
-                              SharedPreferencesHelper().conferenceAliases);
-                        })),
+                  key: formKeyAlias,
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
+                  child: InputTextFormField(
+                    labelText: 'Conference alias',
+                    controller: conferenceAliasTextController,
+                    focusColor: Colors.deepPurple,
+                    isStorageNeeded: true,
+                    onStorageIconTap: () async {
+                      await showAliasSelectorDialog(
+                        context,
+                        SharedPreferencesHelper().conferenceAliases,
+                      );
+                    },
+                  ),
+                ),
                 ExpansionTile(
                     title: const Text('Options'),
                     textColor: Colors.black,
@@ -495,7 +499,9 @@ class _JoinConferenceContentState extends State<JoinConferenceContent> {
   }
 
   Future<void> showAliasSelectorDialog(
-      BuildContext context, List<String>? conferenceAliases) async {
+    BuildContext context,
+    List<String>? conferenceAliases,
+  ) async {
     return showDialog<void>(
         context: context,
         builder: (BuildContext context) {
@@ -503,30 +509,38 @@ class _JoinConferenceContentState extends State<JoinConferenceContent> {
               title: const Text('Choose from recently saved'),
               actionsOverflowButtonSpacing: 10,
               content: SingleChildScrollView(
-                  child: SizedBox(
-                width: double.maxFinite,
-                child: Column(mainAxisSize: MainAxisSize.min, children: [
-                  if (conferenceAliases != null)
-                    ListView.builder(
-                        shrinkWrap: true,
-                        itemCount: conferenceAliases.length,
-                        itemBuilder: (context, index) {
-                          String alias = conferenceAliases[index];
-                          return ListTile(
+                child: SizedBox(
+                  width: double.maxFinite,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (conferenceAliases != null)
+                        ListView.builder(
+                          shrinkWrap: true,
+                          itemCount: conferenceAliases.length,
+                          itemBuilder: (context, index) {
+                            String alias = conferenceAliases[index];
+                            return ListTile(
                               title: Text(alias),
-                              onTap: () => onAliasTap(alias));
-                        })
-                  else
-                    const Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text('No aliases in storage.'))
-                ]),
-              )),
+                              onTap: () => onAliasTap(alias),
+                            );
+                          },
+                        )
+                      else
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('No aliases in storage.'),
+                        )
+                    ],
+                  ),
+                ),
+              ),
               actions: [
                 TextButton(
-                    style: TextButton.styleFrom(primary: Colors.deepPurple),
-                    onPressed: () => Navigator.of(context).pop(),
-                    child: const Text('Cancel')),
+                  style: TextButton.styleFrom(primary: Colors.deepPurple),
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Cancel'),
+                ),
               ]);
         });
   }

--- a/test_app/lib/shared_preferences_helper.dart
+++ b/test_app/lib/shared_preferences_helper.dart
@@ -2,6 +2,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class SharedPreferencesHelper {
   static SharedPreferences? _preferences;
+  static List<String> _conferenceAliases = [];
 
   static Future<void> load() async {
     _preferences ??= await SharedPreferences.getInstance();
@@ -16,7 +17,30 @@ class SharedPreferencesHelper {
   set username(String value) {
     _preferences?.setString(keyUsername, value);
   }
+
+  String get latestAlias => _preferences?.getString(keyLatestAlias) ?? '';
+  set latestAlias(String value) {
+    manageList(value);
+    _preferences?.setString(keyLatestAlias, value);
+  }
+
+  List<String>? get conferenceAliases => _preferences?.getStringList(keyConferenceAliases);
+  set conferenceAliases(List<String>? value) => _preferences?.setStringList(keyConferenceAliases, value ?? []);
+
+  void manageList(String value) {
+    _conferenceAliases = conferenceAliases ?? [];
+
+    if (!_conferenceAliases.contains(value)) {
+      if (_conferenceAliases.length == 5) {
+        _conferenceAliases.removeAt(0);
+      }
+      _conferenceAliases.add(value);
+      conferenceAliases = _conferenceAliases;
+    }
+  }
 }
 
-const String keyAccessToken = "key_access_token";
-const String keyUsername = "key_username";
+const String keyAccessToken = 'key_access_token';
+const String keyUsername = 'key_username';
+const String keyLatestAlias = 'key_latest_alias';
+const String keyConferenceAliases = 'key_conference_aliases';

--- a/test_app/lib/widgets/text_form_field.dart
+++ b/test_app/lib/widgets/text_form_field.dart
@@ -5,13 +5,17 @@ class InputTextFormField extends StatefulWidget {
   final TextEditingController? controller;
   final Color focusColor;
   final String? initialValue;
+  final void Function()? onStorageIconTap;
+  final bool isStorageNeeded;
 
   const InputTextFormField(
       {Key? key,
       required this.labelText,
       required this.controller,
       this.focusColor = Colors.blue,
-      this.initialValue})
+      this.initialValue,
+      this.onStorageIconTap,
+      this.isStorageNeeded = false})
       : super(key: key);
 
   @override
@@ -51,9 +55,20 @@ class _InputTextFormFieldState extends State<InputTextFormField> {
           borderRadius: const BorderRadius.all(Radius.circular(12.0)),
           borderSide: BorderSide(color: widget.focusColor, width: 2),
         ),
-        suffixIcon: IconButton(
-            onPressed: widget.controller!.clear,
-            icon: const Icon(Icons.clear, color: Colors.grey)),
+        suffixIcon: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              widget.isStorageNeeded
+                  ? IconButton(
+                      onPressed: widget.onStorageIconTap,
+                      icon: const Icon(Icons.storage),
+                      color: Colors.grey)
+                  : const SizedBox.shrink(),
+              IconButton(
+                  onPressed: widget.controller!.clear,
+                  icon: const Icon(Icons.clear, color: Colors.grey))
+            ]),
       ),
       validator: (value) => value!.isEmpty ? 'Please, fill this field.' : null,
       controller: widget.controller,

--- a/test_app/lib/widgets/text_form_field.dart
+++ b/test_app/lib/widgets/text_form_field.dart
@@ -56,19 +56,22 @@ class _InputTextFormFieldState extends State<InputTextFormField> {
           borderSide: BorderSide(color: widget.focusColor, width: 2),
         ),
         suffixIcon: Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              widget.isStorageNeeded
-                  ? IconButton(
-                      onPressed: widget.onStorageIconTap,
-                      icon: const Icon(Icons.storage),
-                      color: Colors.grey)
-                  : const SizedBox.shrink(),
-              IconButton(
-                  onPressed: widget.controller!.clear,
-                  icon: const Icon(Icons.clear, color: Colors.grey))
-            ]),
+          mainAxisAlignment: MainAxisAlignment.end,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            widget.isStorageNeeded
+                ? IconButton(
+                    onPressed: widget.onStorageIconTap,
+                    icon: const Icon(Icons.storage),
+                    color: Colors.grey,
+                  )
+                : const SizedBox.shrink(),
+            IconButton(
+              onPressed: widget.controller!.clear,
+              icon: const Icon(Icons.clear, color: Colors.grey),
+            )
+          ],
+        ),
       ),
       validator: (value) => value!.isEmpty ? 'Please, fill this field.' : null,
       controller: widget.controller,


### PR DESCRIPTION
- Save up to 5 last conference aliases, without reduplicate. 
- On start, conference alias field is populated with latest saved alias.
- To select from last saved, click the storage icon next to the clear icon in the text field 'conference alias' and select a value from the list.